### PR TITLE
feat: extend llm_utils to run llama2 via ollama cli

### DIFF
--- a/plan-bench/utils/llm_utils.py
+++ b/plan-bench/utils/llm_utils.py
@@ -1,80 +1,25 @@
 from transformers import StoppingCriteriaList, StoppingCriteria
 import openai
 import os
-openai.api_key = os.environ["OPENAI_API_KEY"]
-def generate_from_bloom(model, tokenizer, query, max_tokens):
-    encoded_input = tokenizer(query, return_tensors='pt')
-    stop = tokenizer("[PLAN END]", return_tensors='pt')
-    stoplist = StoppingCriteriaList([stop])
-    output_sequences = model.generate(input_ids=encoded_input['input_ids'].cuda(), max_new_tokens=max_tokens,
-                                      temperature=0, top_p=1)
-    return tokenizer.decode(output_sequences[0], skip_special_tokes=True)
+import subprocess
 
+def prompt_llama2(query):
+    shellCommand = f"ollama run llama2 '{query}'"
+    result = subprocess.run(shellCommand, shell=True, text=True, capture_output=True)
+
+    if result.returncode == 0:
+        return result.stdout
+    else:
+        return result.stderr
 
 def send_query(query, engine, max_tokens, model=None, stop="[STATEMENT]"):
-    max_token_err_flag = False
-    if engine == 'bloom':
-
-        if model:
-            response = generate_from_bloom(model['model'], model['tokenizer'], query, max_tokens)
-            response = response.replace(query, '')
-            resp_string = ""
-            for line in response.split('\n'):
-                if '[PLAN END]' in line:
-                    break
-                else:
-                    resp_string += f'{line}\n'
-            return resp_string
-        else:
-            assert model is not None
-    elif engine == 'finetuned':
+    if engine == "llama2":
         if model:
             try:
-                response = openai.Completion.create(
-                    model=model['model'],
-                    prompt=query,
-                    temperature=0,
-                    max_tokens=max_tokens,
-                    top_p=1,
-                    frequency_penalty=0,
-                    presence_penalty=0,
-                    stop=["[PLAN END]"])
+                response = prompt_llama2(query)
             except Exception as e:
-                max_token_err_flag = True
-                print("[-]: Failed GPT3 query execution: {}".format(e))
-            text_response = response["choices"][0]["text"] if not max_token_err_flag else ""
-            return text_response.strip()
-        else:
-            assert model is not None
-    elif '_chat' in engine:
-        
-        eng = engine.split('_')[0]
-        # print('chatmodels', eng)
-        messages=[
-        {"role": "system", "content": "You are the planner assistant who comes up with correct plans."},
-        {"role": "user", "content": query}
-        ]
-        try:
-            response = openai.ChatCompletion.create(model=eng, messages=messages, temperature=0)
-        except Exception as e:
-            max_token_err_flag = True
-            print("[-]: Failed GPT3 query execution: {}".format(e))
-        text_response = response['choices'][0]['message']['content'] if not max_token_err_flag else ""
-        return text_response.strip()        
+                print("failed to query llama2 with ollama")
+            return response
     else:
-        try:
-            response = openai.Completion.create(
-                model=engine,
-                prompt=query,
-                temperature=0,
-                max_tokens=max_tokens,
-                top_p=1,
-                frequency_penalty=0,
-                presence_penalty=0,
-                stop=stop)
-        except Exception as e:
-            max_token_err_flag = True
-            print("[-]: Failed GPT3 query execution: {}".format(e))
-
-        text_response = response["choices"][0]["text"] if not max_token_err_flag else ""
-        return text_response.strip()
+        print("invalid engine")
+        return ""


### PR DESCRIPTION
This PR extends `plan-bench/llm_utils` to run the llama2 model via ollama cli