### PR TITLE
refactor: store llm plan as list

### DIFF
--- a/plan-bench/experiments/tot_stepwise.py
+++ b/plan-bench/experiments/tot_stepwise.py
@@ -16,7 +16,7 @@ exp_vote_prompt_v2 = '<plan> {} </plan>\n\nHere are choices for the next action 
 
 exp_validate_prompt = 'Plan:\n{}\n\nDoes the plan satisfy the goal state? Analyze the plan in detail, then conclude in the last line "The plan <does/ does not> satisfy the goal state".'
 
-exp_validate_prompt_v2 = 'Plan:\n{}\n\nWhen I execute this plan from the initial state, will I reach the goal state? Analyze the plan in detail, then conclude in the last line "The plan <does/ does not> satisfy the goal state".'
+exp_validate_prompt_v2 = 'Plan:\n{}\nWhen I execute this plan from the initial state, will I reach the goal state? Analyze the plan in detail, then conclude in the last line "The plan <does/ does not> satisfy the goal state".'
 
 exp_init_tot_prompt = 'What are 2 possible actions for step 1 in reaching the goal state? Explain your actions, then conclude in the last line "The possible actions are: 1. {a} 2. {b}" where a, b are the possible actions.'
 # The possible actions are: 1. Pick up the red block 2. Unstack the blue block from on top of another block 3. Pick up the orange block

--- a/plan-bench/tot_one_shot_pipeline.py
+++ b/plan-bench/tot_one_shot_pipeline.py
@@ -71,7 +71,7 @@ class tot_one_shot_pipeline:
                                 }
             return structured_output
     
-    def save_json(self, prompt_number, prompt_report, next_action=None):
+    def save_json(self, prompt_number, prompt_report, next_action=None, reset_llm_plan=False):
         os.makedirs(f"prompts/blocksworld_3_tot_one_shot/", exist_ok=True)
 
         is_prompt_report_exists = len(self.tot_state["prompts"]) >= prompt_number
@@ -83,6 +83,9 @@ class tot_one_shot_pipeline:
 
         if (next_action is not None):
             self.tot_state["llm_plan"].append(next_action)
+        
+        if (reset_llm_plan):
+            self.tot_state["llm_plan"] = []
         file_name = f'instance-{self.instance_number}'
         with open(f"prompts/blocksworld_3_tot_one_shot/" + file_name + ".json", "w") as f:
             json.dump(self.tot_state, f, indent=4)
@@ -148,7 +151,8 @@ class tot_one_shot_pipeline:
             "response": possible_actions
         }
         print("[INIT] " + possible_actions)
-        self.save_json(prompt_number, report,  '')
+        reset_llm_plan = True
+        self.save_json(prompt_number, report,  None, reset_llm_plan)
         self.vote_prompt_llama3_80b(prompt_number + 1)
 
     def tot_prompt_llama3_80b(self, prompt_number):


### PR DESCRIPTION
This PR refactors the pipeline to store the llm plan as a list to ease (possible) backtracking implementation.

resolves #29 